### PR TITLE
Fix for "Cannot validate input version: value should be a string"

### DIFF
--- a/application/package.rb
+++ b/application/package.rb
@@ -66,7 +66,11 @@ END_OF_USAGE
 
       def main
         pkg = rpcclient("package")
-        pkg_result = pkg.send(configuration[:action], :package => configuration[:package], :version => configuration[:version])
+        if configuration[:version].nil?
+          pkg_result = pkg.send(configuration[:action], :package => configuration[:package])
+        else
+          pkg_result = pkg.send(configuration[:action], :package => configuration[:package], :version => configuration[:version])
+        end
 
         if !pkg_result.empty?
           sender_width = pkg_result.map{|s| s[:sender]}.map{|s| s.length}.max + 3

--- a/spec/application/package_application_spec.rb
+++ b/spec/application/package_application_spec.rb
@@ -110,7 +110,7 @@ module MCollective
 
         it 'should display the correct verbose output' do
           @app.stubs(:configuration).returns({:action => 'uninstall', :package => 'rspec'})
-          package.expects(:send).with('uninstall', :package => 'rspec', :version => nil).returns([{:sender => 'rspec',
+          package.expects(:send).with('uninstall', :package => 'rspec').returns([{:sender => 'rspec',
                                                                                 :statuscode => 0,
                                                                                 :data => {:ensure => 'absent'}}])
           package.expects(:verbose).returns(true)
@@ -120,7 +120,7 @@ module MCollective
 
         it 'should not output for install, update, uninstall and purge' do
           @app.stubs(:configuration).returns({:action => 'uninstall', :package => 'rspec'})
-          package.expects(:send).with('uninstall', :package => 'rspec', :version => nil).returns([{:sender => 'rspec',
+          package.expects(:send).with('uninstall', :package => 'rspec').returns([{:sender => 'rspec',
                                                                                 :statuscode => 0,
                                                                                 :data => {:ensure => 'absent'}}])
           package.expects(:verbose).returns(false)
@@ -130,7 +130,7 @@ module MCollective
 
         it 'should display the correct output for an absent package status' do
           @app.stubs(:configuration).returns({:action => 'status', :package => 'rspec'})
-          package.expects(:send).with('status', :package => 'rspec', :version => nil).returns([{:sender => 'rspec',
+          package.expects(:send).with('status', :package => 'rspec').returns([{:sender => 'rspec',
                                                                                :statuscode => 0,
                                                                                :data => {:ensure => 'absent'}}])
           package.expects(:verbose).returns(false)
@@ -140,7 +140,7 @@ module MCollective
 
         it 'should display the correct output for an installed package status' do
           @app.stubs(:configuration).returns({:action => 'status', :package => 'rspec'})
-          package.expects(:send).with('status', :package => 'rspec', :version => nil).returns([{:sender => 'rspec',
+          package.expects(:send).with('status', :package => 'rspec').returns([{:sender => 'rspec',
                                                                                 :statuscode => 0,
                                                                                 :data => {:ensure => '2.1',
                                                                                           :arch => 'x86',


### PR DESCRIPTION
When trying to install a package without specifying the version:

mco package install package  -I host-01.domain.com -v

the package agent throws this error:

The package application failed to run: Cannot validate input version: value should be a string

Cannot validate input version: value should be a string (MCollective::DDLValidationError)
	from /usr/lib/ruby/site_ruby/1.8/mcollective/ddl/base.rb:140:in `validate_input_argument'  <----
	from /usr/lib/ruby/site_ruby/1.8/mcollective/ddl/agentddl.rb:192:in `validate_rpc_request'
	from /usr/lib/ruby/site_ruby/1.8/mcollective/ddl/agentddl.rb:185:in `each'
	from /usr/lib/ruby/site_ruby/1.8/mcollective/ddl/agentddl.rb:185:in `validate_rpc_request'
	from /usr/lib/ruby/site_ruby/1.8/mcollective/rpc/client.rb:175:in `validate_request'
	from /usr/lib/ruby/site_ruby/1.8/mcollective/rpc/client.rb:246:in `method_missing'
	from /usr/libexec/mcollective/mcollective/application/package.rb:71:in `send'
	from /usr/libexec/mcollective/mcollective/application/package.rb:71:in `main'
	from /usr/lib/ruby/site_ruby/1.8/mcollective/application.rb:293:in `run'
	from /usr/lib/ruby/site_ruby/1.8/mcollective/applications.rb:23:in `run'
	from /usr/bin/mco:33

In "agentddl.rb"  the validate_rpc_request method checks if all arguments from the application are applicable to the rpc agent and then tries to validate all passed arguments. Since version is always passed from the application to the rpc agent, even if it's optional, it will still be validated in "validate_input_argument".