### PR TITLE
MCOP-532 support apt_update and checkupdates actions 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,11 @@
-Gemfile.lock
-ext/packaging
+.project
+/.idea/compiler.xml
+/.idea/copyright/profiles_settings.xml
+/.idea/encodings.xml
+/.idea/misc.xml
+/.idea/modules.xml
+/.idea/.name
+/.idea/scopes/scope_settings.xml
+/.idea/uiDesigner.xml
+/.idea/vcs.xml
+/.idea/workspace.xml

--- a/application/package.rb
+++ b/application/package.rb
@@ -39,12 +39,13 @@ END_OF_USAGE
           handle_message(:raise, 1)
         else
 
-          valid_actions = ['install', 'uninstall', 'purge', 'update', 'status']
+          valid_package_actions = ['install', 'uninstall', 'purge', 'update', 'status']
+          valid_general_actions = ['apt_update', 'checkupdates']
 
-          if valid_actions.include?(ARGV[0])
+          if valid_package_actions.include?(ARGV[0])
             configuration[:action] = ARGV.shift
             configuration[:package] = ARGV.shift
-          elsif valid_actions.include?(ARGV[1])
+          elsif valid_package_actions.include?(ARGV[1])
             configuration[:package] = ARGV.shift
             configuration[:action] = ARGV.shift
           else

--- a/application/package.rb
+++ b/application/package.rb
@@ -55,7 +55,7 @@ The ACTION can be one of the following:
         elsif valid_general_actions.include?(ARGV[0])
             configuration[:action] = ARGV.shift
         else
-          handle_message(:raise, 2, valid_package_actions.join(', ') + valid_general_actions.join(', '))
+          handle_message(:raise, 2, valid_package_actions.join(', ') + ', ' + valid_general_actions.join(', '))
         end
       end
 

--- a/application/package.rb
+++ b/application/package.rb
@@ -14,43 +14,48 @@ The ACTION can be one of the following:
     purge      - uninstall PACKAGE and purge related config files
     update     - update PACKAGE
     status     - determine whether PACKAGE is installed and report its version
-END_OF_USAGE
+      END_OF_USAGE
 
       option :yes,
-             :arguments   => ["--yes", "-y"],
-             :description => "Assume yes on any prompts",
-             :type        => :bool
+      :arguments   => ["--yes", "-y"],
+      :description => "Assume yes on any prompts",
+      :type        => :bool
 
       option :version,
-             :arguments   => ["--version VERSION"],
-             :description => "Optional VERSION to pass to install",
-             :type        => String,
-             :required    => false
+      :arguments   => ["--version VERSION"],
+      :description => "Optional VERSION to pass to install",
+      :type        => String,
+      :required    => false
 
       def handle_message(action, message, *args)
         messages = {1 => 'Please specify package name and action',
-                    2 => "Action has to be one of %s",
-                    3 => "Do you really want to operate on packages unfiltered? (y/n): "}
+          2 => "Action has to be one of %s",
+          3 => "Do you really want to operate on packages unfiltered? (y/n): "}
         send(action, messages[message] % args)
       end
 
       def post_option_parser(configuration)
-        if ARGV.size < 2
-          handle_message(:raise, 1)
-        else
+        valid_package_actions = ['install', 'uninstall', 'purge', 'update', 'status']
+        valid_general_actions = ['apt_update', 'checkupdates']
 
-          valid_package_actions = ['install', 'uninstall', 'purge', 'update', 'status']
-          valid_general_actions = ['apt_update', 'checkupdates']
-
-          if valid_package_actions.include?(ARGV[0])
-            configuration[:action] = ARGV.shift
-            configuration[:package] = ARGV.shift
-          elsif valid_package_actions.include?(ARGV[1])
-            configuration[:package] = ARGV.shift
-            configuration[:action] = ARGV.shift
+        if valid_package_actions.include?(ARGV[0])
+          if ARGV.size < 2
+            handle_message(:raise, 1)
           else
-            handle_message(:raise, 2, valid_actions.join(', '))
+            configuration[:action] = ARGV.shift
+            configuration[:package] = ARGV.shift
           end
+        elsif valid_package_actions.include?(ARGV[1])
+          if ARGV.size < 2
+            handle_message(:raise, 1)
+          else
+            configuration[:package] = ARGV.shift
+            configuration[:action] = ARGV.shift
+          end
+        elsif valid_general_actions.include?(ARGV[0])
+            configuration[:action] = ARGV.shift
+        else
+          handle_message(:raise, 2, valid_package_actions.join(', ') + valid_general_actions.join(', '))
         end
       end
 

--- a/spec/application/package_application_spec.rb
+++ b/spec/application/package_application_spec.rb
@@ -18,14 +18,8 @@ module MCollective
       end
 
       describe '#post_option_parser' do
-        it 'should fail if both an action and package are not supplied' do
-          ARGV << 'rspec'
+        it 'should fail if a action concerning a package is missing the package option' do
           ARGV << 'install'
-          expect{
-            @app.post_option_parser({})
-          }.to raise_error 'Please specify package name and action'
-
-          ARGV.shift
           expect{
             @app.post_option_parser({})
           }.to raise_error 'Please specify package name and action'

--- a/spec/application/package_application_spec.rb
+++ b/spec/application/package_application_spec.rb
@@ -20,6 +20,7 @@ module MCollective
       describe '#post_option_parser' do
         it 'should fail if both an action and package are not supplied' do
           ARGV << 'rspec'
+          ARGV << 'install'
           expect{
             @app.post_option_parser({})
           }.to raise_error 'Please specify package name and action'
@@ -36,7 +37,7 @@ module MCollective
 
           expect{
             @app.post_option_parser({})
-          }.to raise_error 'Action has to be one of install, uninstall, purge, update, status'
+          }.to raise_error 'Action has to be one of install, uninstall, purge, update, status, apt_update, checkupdates'
         end
 
         it 'should parse "action" "package" correctly' do


### PR DESCRIPTION
As described in https://tickets.puppetlabs.com/browse/MCOP-532 the agent actions apt_update and checkupdates are not working with current application. The pull requests updates the application to support these actions