### PR TITLE
(MCOP-575) Adding comma to package_data.ddl

### DIFF
--- a/data/package_data.ddl
+++ b/data/package_data.ddl
@@ -32,7 +32,7 @@ dataquery :description => "package" do
            :display_as => "Package Status"
 
     output :installed,
-           :description => "true/false"
+           :description => "true/false",
            :display_as => "Is installed?"
 end
 


### PR DESCRIPTION
adding a missing "," in the installed output section.