### PR TITLE
(MCOP-575) Add missing comma to package_data.ddl

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,6 +2,7 @@
 source 'https://rubygems.org'
 
 group :test do
+  gem 'json', '~> 1.8.3'
   gem 'rake', '~> 10.4'
   gem 'rspec', '~> 2.11.0'
   gem 'mocha', '~> 0.10.0'

--- a/data/package_data.ddl
+++ b/data/package_data.ddl
@@ -32,7 +32,7 @@ dataquery :description => "package" do
            :display_as => "Package Status"
 
     output :installed,
-           :description => "true/false"
+           :description => "true/false",
            :display_as => "Is installed?"
 end
 


### PR DESCRIPTION
Adds a missing comma that prevented the ddl from loading.

Also fixes CI.
