### PR TITLE
(MCOP-593) add count and md5 methods

### DIFF
--- a/agent/package.ddl
+++ b/agent/package.ddl
@@ -115,6 +115,32 @@ action "status", :description => "Get the status of a package" do
     end
 end
 
+action "count", :description => "Get number of packages installed" do
+    output :output,
+           :description => "Count of packages installed",
+           :display_as  => "Count"
+
+    output :exitcode,
+           :description => "The exitcode from the rpm/dpkg command",
+           :display_as => "Exit Code"
+    summarize do
+      aggregate summary(:output)
+    end
+end
+
+action "md5", :description => "Get md5 digest of list of packages installed" do
+    output :output,
+           :description => "md5 of list of packages installed",
+           :display_as  => "MD5"
+
+    output :exitcode,
+           :description => "The exitcode from the rpm/dpkg command",
+           :display_as => "Exit Code"
+    summarize do
+      aggregate summary(:output)
+    end
+end
+
 action "yum_clean", :description => "Clean the YUM cache" do
     input :mode,
           :prompt      => "Yum clean mode",

--- a/agent/package.rb
+++ b/agent/package.rb
@@ -22,6 +22,18 @@ module MCollective
         Package.do_pkg_action(request[:package], :status, reply)
       end
 
+      action 'count' do
+        result = package_helper.count
+        reply[:exitcode] = result[:exitcode]
+        reply[:output] = result[:output]
+      end
+
+     action 'md5' do
+        result = package_helper.md5
+        reply[:exitcode] = result[:exitcode]
+        reply[:output] = result[:output]
+      end
+
       action 'yum_clean' do
         clean_mode = request[:mode] || @config.pluginconf.fetch('package.yum_clean_mode', 'all')
         result = package_helper.yum_clean(clean_mode)

--- a/application/package.rb
+++ b/application/package.rb
@@ -59,7 +59,7 @@ END_OF_USAGE
       end
 
       def validate_configuration(configuration)
-        unless configuration[:action] == 'status'
+        unless [ 'status', 'count', 'md5'].include?(configuration[:action])
           if Util.empty_filter?(options[:filter]) && !configuration[:yes]
             handle_message(:print, 3)
 

--- a/application/package.rb
+++ b/application/package.rb
@@ -6,6 +6,7 @@ module MCollective
       usage <<-END_OF_USAGE
 mco package [OPTIONS] [FILTERS] <ACTION> <PACKAGE>
 Usage: mco package <PACKAGE> <install|uninstall|purge|update|status>
+       mco package <count|md5>
 
 The ACTION can be one of the following:
 

--- a/spec/agent/package_agent_spec.rb
+++ b/spec/agent/package_agent_spec.rb
@@ -125,6 +125,43 @@ module MCollective
         end
       end
 
+      describe '#count' do
+
+        it 'should perform package count' do
+          helper = mock
+          @agent.stubs(:package_helper).returns(helper)
+          helper.expects(:count).returns({:exitcode => 0, :output => 'pkgcount'})
+
+          result = @agent.call(:count)
+          result.should be_successful
+          result.should have_data_items({:exitcode => 0, :output => 'pkgcount'})
+        end
+
+        it 'should fail if the command failed' do
+          @agent.stubs(:package_helper).raises('rspec_error')
+          result = @agent.call(:count)
+          result.should be_unknown_error
+        end
+      end
+
+      describe '#md5' do
+        it 'should perform package list md5' do
+          helper = mock
+          @agent.stubs(:package_helper).returns(helper)
+          helper.expects(:md5).returns({:exitcode => 0, :output => 'pkgmd5'})
+
+          result = @agent.call(:md5)
+          result.should be_successful
+          result.should have_data_items({:exitcode => 0, :output => 'pkgmd5'})
+        end
+
+        it 'should fail if the command failed' do
+          @agent.stubs(:package_helper).raises('rspec_error')
+          result = @agent.call(:md5)
+          result.should be_unknown_error
+        end
+      end
+
       describe '#apt_update' do
         it 'should perform an apt update' do
           helper = mock

--- a/spec/application/package_application_spec.rb
+++ b/spec/application/package_application_spec.rb
@@ -36,7 +36,7 @@ module MCollective
 
           expect{
             @app.post_option_parser({})
-          }.to raise_error 'Action has to be one of install, uninstall, purge, update, status'
+          }.to raise_error 'Action has to be one of install, uninstall, purge, update, status, count, md5'
         end
 
         it 'should parse "action" "package" correctly' do
@@ -147,6 +147,28 @@ module MCollective
                                                                                           :name => 'rspec'}}])
           package.expects(:verbose).returns(false)
           @app.expects(:puts).with(pattern % ['rspec', 'rspec-2.1.x86'])
+          @app.main
+        end
+
+        it 'should display the correct output for a count of packages' do
+          @app.stubs(:configuration).returns({:action => 'count'})
+          package.expects(:send).with('count', :package => nil).returns([{:sender => 'rspec',
+                                                         :statuscode => 0,
+                                                         :data => {:exitcode => 0,
+                                                                   :output => 'pkgcount'}}])
+          package.expects(:verbose).returns(false)
+          @app.expects(:puts).with(pattern % ['rspec', 'pkgcount'])
+          @app.main
+        end
+
+        it 'should display the correct output for a MD5 of the package list' do
+          @app.stubs(:configuration).returns({:action => 'md5'})
+          package.expects(:send).with('md5', :package => nil).returns([{:sender => 'rspec',
+                                                         :statuscode => 0,
+                                                         :data => {:exitcode => 0,
+                                                                   :output => 'pkgmd5'}}])
+          package.expects(:verbose).returns(false)
+          @app.expects(:puts).with(pattern % ['rspec', 'pkgmd5'])
           @app.main
         end
       end

--- a/spec/application/package_application_spec.rb
+++ b/spec/application/package_application_spec.rb
@@ -95,6 +95,13 @@ module MCollective
           @app.expects(:handle_message).never
           @app.validate_configuration({:yes => true})
         end
+
+        it 'should not prompt when action count even if yes flag is unset and filter is empty' do
+          Util.expects(:empty_filter?).never
+          @app.stubs(:options).returns({:filter => {}})
+          @app.expects(:handle_message).never
+          @app.validate_configuration({:action => 'count'})
+        end
       end
 
       describe '#main' do

--- a/spec/application/package_application_spec.rb
+++ b/spec/application/package_application_spec.rb
@@ -102,6 +102,13 @@ module MCollective
           @app.expects(:handle_message).never
           @app.validate_configuration({:action => 'count'})
         end
+
+        it 'should not prompt when action md5 even if yes flag is unset and filter is empty' do
+          Util.expects(:empty_filter?).never
+          @app.stubs(:options).returns({:filter => {}})
+          @app.expects(:handle_message).never
+          @app.validate_configuration({:action => 'md5'})
+        end
       end
 
       describe '#main' do


### PR DESCRIPTION
Adding count and md5 methods:
mco package count -T ... -F ....
to count the number of packages, like rpm -qa | wc -l
as well as
mco package md5
to get a MD5 digest of the package list, like rpm -qa | md5
across a cluster are very useful to us.